### PR TITLE
Allow custom day formatter

### DIFF
--- a/src/DateRangePicker.elm
+++ b/src/DateRangePicker.elm
@@ -107,6 +107,13 @@ type alias Config =
     { allowFuture : Bool
     , applyRangeImmediately : Bool
     , class : String
+    , dayFormatter :
+        Time.Zone
+        ->
+            { day : Time.Posix
+            , today : Time.Posix
+            }
+        -> Html Never
     , inputClass : String
     , monthFormatter : Time.Month -> String
     , noRangeCaption : String
@@ -152,6 +159,10 @@ defaultConfig =
     { allowFuture = True
     , applyRangeImmediately = True
     , class = ""
+    , dayFormatter =
+        \zone days ->
+            Helpers.dayToString zone days
+                |> Html.text
     , inputClass = ""
     , monthFormatter = Helpers.monthToString
     , noRangeCaption = "N/A"
@@ -509,6 +520,7 @@ panel toMsg (State internal) =
             { allowFuture = internal.config.allowFuture
             , hover = \posix -> handleEvent toMsg (Hover posix) internal
             , hovered = internal.hovered
+            , dayFormatter = internal.config.dayFormatter
             , monthFormatter = internal.config.monthFormatter
             , next = Nothing
             , noOp = handleEvent toMsg NoOp internal

--- a/src/DateRangePicker/Calendar.elm
+++ b/src/DateRangePicker/Calendar.elm
@@ -22,6 +22,13 @@ type alias Translations =
 
 type alias Config msg =
     { allowFuture : Bool
+    , dayFormatter :
+        Time.Zone
+        ->
+            { day : Time.Posix
+            , today : Time.Posix
+            }
+        -> Html Never
     , monthFormatter : Time.Month -> String
     , hover : Posix -> msg
     , hovered : Maybe Posix
@@ -80,7 +87,7 @@ inRangePath zone maybeHovered begin day =
 
 
 dayCell : Config msg -> Posix -> Html msg
-dayCell { allowFuture, hover, hovered, noOp, pick, step, target, today, zone } day =
+dayCell { allowFuture, dayFormatter, hover, hovered, noOp, pick, step, target, today, zone } day =
     let
         base =
             { active = False
@@ -134,7 +141,12 @@ dayCell { allowFuture, hover, hovered, noOp, pick, step, target, today, zone } d
                     [ onClick noOp ]
                )
         )
-        [ day |> Time.toDay zone |> String.fromInt |> text ]
+        [ dayFormatter zone
+            { day = day
+            , today = today
+            }
+            |> Html.map never
+        ]
 
 
 navLink : String -> Maybe msg -> Html msg

--- a/src/DateRangePicker/Helpers.elm
+++ b/src/DateRangePicker/Helpers.elm
@@ -1,5 +1,6 @@
 module DateRangePicker.Helpers exposing
-    ( formatDate
+    ( dayToString
+    , formatDate
     , formatDateTime
     , formatTime
     , monthToString
@@ -12,6 +13,19 @@ module DateRangePicker.Helpers exposing
 
 import Time exposing (Posix)
 import Time.Extra as TE
+
+
+dayToString :
+    Time.Zone
+    ->
+        { day : Time.Posix
+        , today : Time.Posix
+        }
+    -> String
+dayToString zone { day } =
+    day
+        |> Time.toDay zone
+        |> String.fromInt
 
 
 formatDate : Time.Zone -> Posix -> String


### PR DESCRIPTION
Not sure if you're looking for contributions, but I am working through some changes made to fit my use case.

For this, I needed a custom day formatted because I wanted to show the relative offset from today below the day of the month:
![image](https://user-images.githubusercontent.com/289969/171700880-0d3ba10f-bdb6-4aae-94aa-dd83a330b2da.png)

That's why it expects a function with the zone, day, & today and returns `Html Never`:
```elm
dayFormatter :
    Time.Zone
    ->
        { day : Time.Posix
        , today : Time.Posix
        }
    -> Html Never
```

If you're not interested in this change, please feel free to decline.